### PR TITLE
[14.0] [MIG] base_delivery_carrier_label: port pr from 12.0 to 14.0

### DIFF
--- a/base_delivery_carrier_label/models/delivery_carrier_option.py
+++ b/base_delivery_carrier_label/models/delivery_carrier_option.py
@@ -2,7 +2,7 @@
 # Copyright 2013-2016 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class DeliveryCarrierOption(models.Model):
@@ -19,7 +19,11 @@ class DeliveryCarrierOption(models.Model):
 
     active = fields.Boolean(default=True)
     mandatory = fields.Boolean(
-        help="If checked, this option is necessarily applied " "to the delivery order"
+        help=(
+            "If checked, this option is necessarily applied "
+            "to the delivery order. Mandatory options show up in orange "
+            "in the option widget on the picking."
+        ),
     )
     by_default = fields.Boolean(
         string="Applied by Default",
@@ -38,3 +42,13 @@ class DeliveryCarrierOption(models.Model):
         help="When True, help to prevent the user to modify some fields "
         "option (if attribute is defined in the view)",
     )
+    color = fields.Integer(
+        compute="_compute_color",
+        help="Orange if the option is mandatory, otherwise no color",
+    )
+
+    @api.depends("mandatory")
+    def _compute_color(self):
+        """Show that a tag is mandatory using the color attribute"""
+        for tag in self:
+            tag.color = 2 if tag.mandatory else False

--- a/base_delivery_carrier_label/tests/carrier_label_case.py
+++ b/base_delivery_carrier_label/tests/carrier_label_case.py
@@ -90,6 +90,8 @@ class CarrierLabelCase(TransactionCase):
             return
         self.fail("No labels found")
 
+
+class TestCarrierLabel(CarrierLabelCase):
     def test_labels(self):
         """Test if labels are created by the button"""
         self.picking.send_to_shipper()

--- a/base_delivery_carrier_label/tests/carrier_label_case.py
+++ b/base_delivery_carrier_label/tests/carrier_label_case.py
@@ -13,6 +13,10 @@ class CarrierLabelCase(TransactionCase):
         super().setUp(*args, **kwargs)
         self._create_order_picking()
 
+    @property
+    def transfer_in_setup(self):
+        return True
+
     def _create_order_picking(self):
         """Create a sale order and deliver the picking"""
         self.order = self.env["sale.order"].create(self._sale_order_data())
@@ -29,6 +33,10 @@ class CarrierLabelCase(TransactionCase):
         self.order.action_confirm()
         self.picking = self.order.picking_ids
         self.picking.write(self._picking_data())
+        if self.transfer_in_setup:
+            self._transfer_order_picking()
+
+    def _transfer_order_picking(self):
         self.env["stock.immediate.transfer"].create(
             {"pick_ids": [(6, 0, self.picking.ids)]}
         ).process()

--- a/base_delivery_carrier_label/tests/test_helper_functions.py
+++ b/base_delivery_carrier_label/tests/test_helper_functions.py
@@ -73,3 +73,15 @@ class TestHelperFunctions(TransactionCase):
             )
         )
         self.assertEqual(label.name, "hello_world.pdf")
+
+    def test_delivery_carrier_option(self):
+        """Mandatory option on delivery options sets color"""
+        option = self.env["delivery.carrier.option"].create(
+            {
+                "name": __name__,
+                "code": __name__,
+            }
+        )
+        self.assertFalse(option.color)
+        option.mandatory = True
+        self.assertEqual(option.color, 2)

--- a/base_delivery_carrier_label/views/delivery.xml
+++ b/base_delivery_carrier_label/views/delivery.xml
@@ -6,11 +6,16 @@
         <field name="model">delivery.carrier.template.option</field>
         <field name="arch" type="xml">
             <form string="delivery_carrier_option">
-                <field name="partner_id" />
-                <field name="code" />
-                <field name="name" />
-                <newline />
-                <field name="description" />
+                <group>
+                  <group>
+                    <field name="name" />
+                  </group>
+                  <group>
+                    <field name="partner_id" />
+                    <field name="code" />
+                  </group>
+                  <field name="description" />
+                </group>
             </form>
         </field>
     </record>

--- a/base_delivery_carrier_label/views/delivery.xml
+++ b/base_delivery_carrier_label/views/delivery.xml
@@ -10,7 +10,7 @@
                 <field name="code" />
                 <field name="name" />
                 <newline />
-                <field name="description" colspan="4" />
+                <field name="description" />
             </form>
         </field>
     </record>
@@ -33,24 +33,27 @@
         <field name="model">delivery.carrier.option</field>
         <field name="arch" type="xml">
             <form string="delivery_carrier_option">
-                <group col="4">
+            <group>
+                <group>
                     <field name="active" />
                     <field
-                        name="mandatory"
-                        attrs="{'readonly': [('readonly_flag','=',True)]}"
-                    />
+                            name="mandatory"
+                            attrs="{'readonly': [('readonly_flag','=',True)]}"
+                        />
                     <field
-                        name="by_default"
-                        attrs="{'invisible': [('mandatory', '=', True)]}"
-                    />
+                            name="by_default"
+                            attrs="{'invisible': [('mandatory', '=', True)]}"
+                        />
                     <field name="readonly_flag" attrs="{'invisible': True}" />
+                </group>
+                <group>
                     <field
-                        name="tmpl_option_id"
-                        colspan="4"
-                        attrs="{'readonly': [('readonly_flag','=',True)]}"
-                    />
-                    <newline />
-                    <field name="description" colspan="4" readonly="True" />
+                            name="tmpl_option_id"
+                            attrs="{'readonly': [('readonly_flag','=',True)]}"
+                        />
+                </group>
+                <newline />
+                    <field name="description" readonly="True" />
                 </group>
             </form>
         </field>

--- a/base_delivery_carrier_label/views/stock.xml
+++ b/base_delivery_carrier_label/views/stock.xml
@@ -8,9 +8,12 @@
         <field name="arch" type="xml">
             <xpath expr="//page//field[@name='carrier_id']" position="after">
                 <field name="carrier_code" />
-            </xpath>
-            <xpath expr="//page//group[@name='carrier_data']/.." position="after">
-                <field name="option_ids" domain="[('carrier_id', '=', carrier_id)]" />
+                <field
+                    name="option_ids"
+                    domain="[('carrier_id', '=', carrier_id)]"
+                    widget="many2many_tags"
+                    options="{'color_field': 'color', 'no_create_edit': True}"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
*[[12.0] postlogistics - Fix writing of tracking_number](https://github.com/OCA/delivery-carrier/pull/311)
*[[12.0][RFR] base_delivery_carrier_label: show options as tags](https://github.com/OCA/delivery-carrier/pull/345)
*[[12.0][RFR] carrier label tests: extract Test classes from Case classes for easier overriding](https://github.com/OCA/delivery-carrier/pull/352)
*[[12.0][FIX] base_delivery_carrier_label: form views usability](https://github.com/OCA/delivery-carrier/pull/391)